### PR TITLE
fixed typo: idempontent --> idempotent

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@ var boolFnAppliedThrice =
 jsc.assert(boolFnAppliedThrice);
 <span class="comment">// OK, passed 100 tests</span></code></pre>
 
-    <h3><a name="sort-idempotent" class="anchor" href="#sort-idempotent">Sort is idempontent</a></h3>
+    <h3><a name="sort-idempotent" class="anchor" href="#sort-idempotent">Sort is idempotent</a></h3>
 
   <p>A unary operation (or function) is idempotent if, whenever it is applied twice to any value, it gives the same result as if it were applied once; i.e., <em>ƒ(ƒ(x)) ≡ ƒ(x)</em>. For example, sort: <em>sort(sort(x)) ≡ sort(x)</em>.</p>
 


### PR DESCRIPTION
I got confused and scared that I might have misspelled this all my life. But it turned out it was just a typo.